### PR TITLE
Update part4d.md

### DIFF
--- a/src/content/4/en/part4d.md
+++ b/src/content/4/en/part4d.md
@@ -154,8 +154,8 @@ const jwt = require('jsonwebtoken') //highlight-line
   //highlight-start
 const getTokenFrom = request => {
   const authorization = request.get('authorization')
-  if (authorization && authorization.toLowerCase().startsWith('bearer ')) {
-    return authorization.substring(7)
+  if (authorization && authorization.startsWith('Bearer ')) {
+    return authorization.replace(/^Bearer /, '')
   }
   return null
 }


### PR DESCRIPTION
I think it seems a bit minor issue, but I suggest a small change in  the [part where we parse the authorization header](https://fullstackopen.com/en/part4/token_authentication#limiting-creating-new-notes-to-logged-in-users). It is in line 156.

A few reasons for this suggestions are the followings:
- We don't rely on a specific index(here `7`) for parsing, using regex instead
- According to [RFC6750 Section 2.1](https://www.rfc-editor.org/rfc/rfc6750#section-2.1) they specify that the Authorization header starts with "Bearer".  (I think there are some issues regarding this "B" case sensitivity(for example, this issue: https://github.com/golang/oauth2/issues/113), but I think it would be better to stick to what's conventional at the moment)
- Moreover, the current code `authorization.toLowerCase().startsWith('bearer ')` allows some undesirable cases like `beARER' or `BEARER', let alone `bearer`, due to the method `toLowerCase()`

Please let me know if there is something I am misunderstanding or something else that is wrong.  Thank you for fantastic resources for learning webdev!